### PR TITLE
Fix for Nim devel

### DIFF
--- a/glfw.nim
+++ b/glfw.nim
@@ -22,7 +22,13 @@ export wrapper.MouseButton
 export wrapper.mbLeft
 export wrapper.mbRight
 export wrapper.mbMiddle
-export wrapper.ModifierKey
+#export wrapper.ModifierKey
+type
+  ModifierKey* = enum
+    mkShift = "shift"
+    mkCtrl ="ctrl"
+    mkAlt = "alt"
+    mkSuper = "super"
 export wrapper.Key
 export wrapper.KeyAction
 export wrapper.OpenglProfile
@@ -115,11 +121,12 @@ converter toHandle(w: Window): WindowHandle = w.handle
 proc initModifierKeySet(bitfield: int): set[ModifierKey] =
   # XXX: This should not be necessary just because the enum type has
   # non-consecutive elements.
-  let mods = [ModifierKey.mkShift, ModifierKey.mkCtrl, ModifierKey.mkAlt, ModifierKey.mkSuper]
-  for m in mods:
+  let mods = [wrapper.ModifierKey.mkShift, wrapper.ModifierKey.mkCtrl, 
+    wrapper.ModifierKey.mkAlt, wrapper.ModifierKey.mkSuper]
+  for i, m in pairs mods:
     let bit = (bitfield.int and m.int)
     if bit != 0:
-      result.incl(bit.ModifierKey)
+      result.incl(ModifierKey i)
 
 type
   ErrorType* {.size: int32.sizeof.} = enum


### PR DESCRIPTION
It should be compatible with older versions, except for cases where the underlying value of the ModifierKey enum is retrieved, which probably nobody does.

I tried to modify as little code as possible, feel free to suggest any changes.

Fixes #41 