### PR TITLE
Add glfwJustCdecl conditional symbol

### DIFF
--- a/glfw/wrapper.nim
+++ b/glfw/wrapper.nim
@@ -2,7 +2,9 @@ static:
   assert cshort.sizeof == int16.sizeof and cint.sizeof == int32.sizeof,
     "not binary compatible with GLFW. Please report this"
 
-when not defined(glfwStaticLib):
+when defined(glfwJustCdecl):
+  {.pragma: glfwImport, cdecl.}
+elif not defined(glfwStaticLib):
   when defined(windows):
     const GlfwDll = "glfw3.dll"
   elif defined(macosx):


### PR DESCRIPTION
I'm writing a wrapper for [Raylib](https://www.raylib.com/index.html), a game development library that comes with GLFW embedded inside it. My wrapper is written using nimterop, which generates symbols automatically from the headers.

I need to access GLFW APIs as well as Raylib APIs, so I tried using this package for its nice API wrapper, but it has a strong expectation that it's either loading a DLL or compiling the library itself.

It seems like the simplest thing to do is add a symbol that lets me circumvent all of at and just import the C declarations. So I can import raylib with nimterop, link raylib in however I want, and import glfw to get the symbols. It's worked great so far!